### PR TITLE
Ignore .eggs cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 #################
 *.pyc
 *.egg-info/
+.eggs
 __pycache__/
 *.py[cod]
 


### PR DESCRIPTION
Minor update for when someone runs the `python setup.py install` installation method.